### PR TITLE
Login redis

### DIFF
--- a/src/main/java/com/MooBoo/MooBoo_Spring/adapter/inbound/api/login/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/adapter/inbound/api/login/CustomOAuth2SuccessHandler.java
@@ -28,6 +28,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -64,8 +65,12 @@ public class CustomOAuth2SuccessHandler implements AuthenticationSuccessHandler 
             nickName = oAuthUserInfo.getUserName();
         }
 
-        String accessToken = jwtProvider.createAccessToken(userId, roles, nickName);
-        String refreshToken = jwtProvider.createRefreshToken(userId);
+        String uuid = UUID.randomUUID().toString();
+
+        // refresh 토큰이 존재하면 제거하기 위함
+        refreshTokenService.find(userId, uuid);
+        String accessToken = jwtProvider.createAccessToken(userId, roles, nickName, uuid);
+        String refreshToken = jwtProvider.createRefreshToken(userId, uuid);
 
         log.info("로그인 AccessToken 발급: "+ accessToken);
         log.info("로그인 RefreshToken 발급: "+ refreshToken);

--- a/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/external/jwt/JwtProviderImpl.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/external/jwt/JwtProviderImpl.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * AccessToken 생성하기
@@ -43,15 +44,14 @@ public class JwtProviderImpl implements JwtProvider {
     private String secretKey;
     @Value("${jwt.access-token-validity}")
     private long accessTokenValidity;
-    @Value("${jwt.refresh-token-validity}")
-    private long refreshTokenValidity;
 
     @Override
-    public String createAccessToken(String userId, List<String> roles, String nickName) {
+    public String createAccessToken(String userId, List<String> roles, String nickName, String uuid) {
         Claims claims = Jwts.claims().setSubject(userId);
         claims.put("roles", roles);
         // FIXME 카카오톡 이름 그대로 노출되므로 변경 필요 (개인정보보호)
         claims.put("nickname", nickName);
+        claims.put("uuid", uuid);
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -62,10 +62,10 @@ public class JwtProviderImpl implements JwtProvider {
     }
 
     @Override
-    public String createRefreshToken(String userId) {
+    public String createRefreshToken(String userId, String uuid) {
         // 오페이크 토큰 생성
         String refreshToken = refreshTokenGenerator.createOpaqueToken();
-        refreshTokenService.save(CreateRefreshToken.create(userId, refreshToken));
+        refreshTokenService.save(CreateRefreshToken.create(userId, refreshToken, uuid));
         return refreshToken;
     }
 
@@ -88,6 +88,12 @@ public class JwtProviderImpl implements JwtProvider {
     public String getUserId(String token) {
         return getClaims(token)
                 .getSubject();
+    }
+
+    @Override
+    public String getUUID(String token) {
+        return getClaims(token)
+                .get("uuid", String.class);
     }
 
     @Override

--- a/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/persistence/refreshtoken/RedisRefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/persistence/refreshtoken/RedisRefreshTokenRepositoryImpl.java
@@ -3,8 +3,8 @@ package com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken;
 import com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken.dto.RefreshTokenDto;
 import com.MooBoo.MooBoo_Spring.application.port.outbound.persistence.RefreshTokenRepository;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.stereotype.Repository;
 
@@ -17,21 +17,45 @@ public class RedisRefreshTokenRepositoryImpl implements RefreshTokenRepository {
 
     private final RedisOperations<String, Object> redisOperations;
 
-    private static final String PREFIX = "refresh:";
+    private static final String PREFIX_USER = "refresh:user:";
+    private static final String PREFIX_UUID = "refresh:uuid:";
+
+    @Value("${jwt.refresh-token-validity}")
+    private long refreshTokenValidity;
+
     @Override
-    public Optional<RefreshTokenDto> findByOpaqueToken(String opaqueToken) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        Object raw = redisOperations.opsForValue().get(PREFIX + opaqueToken);
-        return Optional.ofNullable(raw)
-                .map(o -> objectMapper.convertValue(o, RefreshTokenDto.class));
+    public Optional<String> findUUIDByUserId(String userId) {
+        String findUUID = (String) redisOperations.opsForValue().get(PREFIX_USER + userId);
+        return Optional.ofNullable(findUUID);
     }
 
     @Override
-    public void saveRefreshToken(RefreshTokenDto reFreshTokenDto) {
+    public Optional<String> findRefreshByUUID(String uuid) {
+        String opaqueToken = (String) redisOperations.opsForValue().get(PREFIX_UUID + uuid);
+        return Optional.ofNullable(opaqueToken);
+    }
+
+    @Override
+    public void saveRefreshToken(RefreshTokenDto refreshTokenDto) {
         redisOperations.opsForValue().set(
-                PREFIX + reFreshTokenDto.getOpaqueToken(),
-                reFreshTokenDto,
-                7, TimeUnit.DAYS
+                PREFIX_USER + refreshTokenDto.getUserId(),
+                refreshTokenDto.getUuid(),
+                refreshTokenValidity, TimeUnit.DAYS
         );
+        redisOperations.opsForValue().set(
+                PREFIX_UUID + refreshTokenDto.getUuid(),
+                refreshTokenDto.getOpaqueToken(),
+                refreshTokenValidity, TimeUnit.DAYS
+        );
+    }
+
+    @Override
+    public void deleteRefreshToken(String uuid) {
+        redisOperations.delete(PREFIX_UUID + uuid);
+    }
+
+    @Override
+    public void deleteUUID(String userId) {
+        redisOperations.delete(PREFIX_USER + userId);
     }
 }

--- a/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/persistence/refreshtoken/dto/CreateRefreshToken.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/persistence/refreshtoken/dto/CreateRefreshToken.java
@@ -10,11 +10,13 @@ import lombok.Data;
 public class CreateRefreshToken {
     private String userId;
     private String opaqueToken;
+    private String uuid;
 
-    public static CreateRefreshToken create(String userId, String opaqueToken) {
+    public static CreateRefreshToken create(String userId, String opaqueToken, String uuid) {
         return CreateRefreshToken.builder()
                 .userId(userId)
                 .opaqueToken(opaqueToken)
+                .uuid(uuid)
                 .build();
     }
 }

--- a/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/persistence/refreshtoken/dto/RefreshTokenDto.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/adapter/outbound/persistence/refreshtoken/dto/RefreshTokenDto.java
@@ -8,12 +8,14 @@ import lombok.*;
 public class RefreshTokenDto {
     private String opaqueToken;
     private String userId;
+    private String uuid;
 
     //== 변환 메서드==//
     public static RefreshTokenDto to(CreateRefreshToken createRefreshToken) {
         return RefreshTokenDto.builder()
                 .opaqueToken(createRefreshToken.getOpaqueToken())
                 .userId(createRefreshToken.getUserId())
+                .uuid(createRefreshToken.getUuid())
                 .build();
     }
 }

--- a/src/main/java/com/MooBoo/MooBoo_Spring/application/port/inbound/bookapi/RefreshTokenService.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/application/port/inbound/bookapi/RefreshTokenService.java
@@ -1,13 +1,11 @@
 package com.MooBoo.MooBoo_Spring.application.port.inbound.bookapi;
 
 import com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken.dto.CreateRefreshToken;
-import com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken.dto.RefreshTokenDto;
-import com.MooBoo.MooBoo_Spring.domain.refreshtoken.RefreshToken;
 
 import java.util.Optional;
 
 public interface RefreshTokenService {
-    Optional<RefreshTokenDto> find(String opaqueToken);
+    Optional<String> find(String userId, String uuid);
 
     void save(CreateRefreshToken createRefreshToken);
 

--- a/src/main/java/com/MooBoo/MooBoo_Spring/application/port/outbound/external/jwt/JwtProvider.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/application/port/outbound/external/jwt/JwtProvider.java
@@ -7,13 +7,15 @@ import java.util.List;
 
 public interface JwtProvider {
 
-    String createAccessToken(String userId, List<String> roles, String nickName);
+    String createAccessToken(String userId, List<String> roles, String nickName, String uuid);
 
-    String createRefreshToken(String userId);
+    String createRefreshToken(String userId, String uuid);
 
     TokenStatus validateToken(String token);
 
     String getUserId(String token);
+
+    String getUUID(String token);
 
     List<String> getRoles(String token);
 

--- a/src/main/java/com/MooBoo/MooBoo_Spring/application/port/outbound/persistence/RefreshTokenRepository.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/application/port/outbound/persistence/RefreshTokenRepository.java
@@ -5,8 +5,14 @@ import com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken.dto.Re
 import java.util.Optional;
 
 public interface RefreshTokenRepository {
-    Optional<RefreshTokenDto> findByOpaqueToken(String opaqueToken);
+    Optional<String> findUUIDByUserId(String userId);
+
+    Optional<String> findRefreshByUUID(String uuid);
 
     void saveRefreshToken(RefreshTokenDto refreshTokenDto);
+
+    void deleteRefreshToken(String uuid);
+
+    void deleteUUID(String uuid);
 
 }

--- a/src/main/java/com/MooBoo/MooBoo_Spring/application/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/application/service/RefreshTokenServiceImpl.java
@@ -5,11 +5,13 @@ import com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken.dto.Re
 import com.MooBoo.MooBoo_Spring.application.port.inbound.bookapi.RefreshTokenService;
 import com.MooBoo.MooBoo_Spring.application.port.outbound.persistence.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -18,8 +20,21 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
-    public Optional<RefreshTokenDto> find(String opaqueToken) {
-        return refreshTokenRepository.findByOpaqueToken(opaqueToken);
+    public Optional<String> find(String userId, String uuid) {
+
+        Optional<String> findUUID = refreshTokenRepository.findUUIDByUserId(userId);
+
+        // UUID가 없거나 일치하지 않는 경우
+        if (findUUID.isEmpty() || !uuid.equals(findUUID.get())) {
+            log.info("UUID가 없거나 UUID가 일치하지 않습니다.");
+            if (!findUUID.isEmpty()) {
+                refreshTokenRepository.deleteRefreshToken(findUUID.get());
+            }
+            refreshTokenRepository.deleteUUID(userId);
+            return Optional.empty();
+        }
+
+        return refreshTokenRepository.findRefreshByUUID(findUUID.get());
     }
 
     @Override

--- a/src/main/java/com/MooBoo/MooBoo_Spring/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/MooBoo/MooBoo_Spring/common/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.MooBoo.MooBoo_Spring.common.filter;
 
-import com.MooBoo.MooBoo_Spring.adapter.outbound.persistence.refreshtoken.dto.RefreshTokenDto;
 import com.MooBoo.MooBoo_Spring.application.port.inbound.bookapi.RefreshTokenService;
 import com.MooBoo.MooBoo_Spring.application.port.outbound.external.jwt.JwtProvider;
 import com.MooBoo.MooBoo_Spring.domain.TokenStatus;
@@ -52,15 +51,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } else if (accessToken != null && !accessToken.isBlank() && tokenStatus == TokenStatus.EXPIRED) {
             log.info("토큰 기간 만료");
             String refreshToken = extractRefreshToken(request);
-
-            Optional<RefreshTokenDto> result = refreshTokenService.find(refreshToken);
             String userId = jwtProvider.getUserId(accessToken);
+            String uuid = jwtProvider.getUUID(accessToken);
+
+            Optional<String> result = refreshTokenService.find(userId, uuid);
 
             log.info("사용자가 쿠키에 전송한 RefreshToken: " + refreshToken);
-            if (refreshToken != null && !result.isEmpty() && !result.isEmpty() && userId.equals(result.get().getUserId())) {
+            if (refreshToken != null && !result.isEmpty()) {
                 List<String> roles = jwtProvider.getRoles(accessToken);
                 String nickName = jwtProvider.getNickName(accessToken);
-                accessToken = jwtProvider.createAccessToken(userId, roles, nickName);
+                accessToken = jwtProvider.createAccessToken(userId, roles, nickName, uuid);
 
                 log.info("AccessToken userId: " + userId);
                 log.info("AccessToken nickName: " + nickName);
@@ -77,13 +77,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
             } else {
-                log.warn("리프래시에 문제 발생 // 없음 or 유저 불일치");
+                log.error("리프래시에 문제 발생 // 없음 or 유저 불일치");
                 respondInvalidToken(response);
                 return;
             }
 
         } else {
-            log.warn("유효하지 않은 AccessToken");
+            log.error("유효하지 않은 AccessToken");
             respondInvalidToken(response);
             return;
         }


### PR DESCRIPTION
🏷️ 이슈 번호
# 10

📝 개요  
### Refresh UUID를 이용하여 관리
- redis에 UUID와 refresh 토큰을 저장 
- accessToken이 만료되어 재발급할 때, 
   accessToken의 claims 중 uuid값과 redis에서 관리되는 uuid 값이 일치해야 리프레시 토큰 재발급 가능
- RefreshRepository, RefreshService 인터페이스 메서드 추가 및 매개변수 추가
- RedisRefreshRepositoryImpl, RefreshServiceImpe 메서드 추가 및 매개변수, 로직 변경
- JwtProvider 인터페이스에서 createAccessToken, createRefreshToken 메서드 매개변수 추가
- JwtProvider 인터페이스에 맞게 수정 
- CustomOAuth2SuccessHandler에서 로그인 후, redis에 있던 기존 유저의 uuid, refresh 토큰 제거 후 
   accessToken, refreshToken 발급
- JwtAuthenticationFilter에서 accessToken에서 uuid 값을 꺼내고 RefreshToken 검사 및 AccessToken 생성시 사용하도록 변경 
- 로그 일부 수정

---

🚀 PR 유형  
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

📷 스크린샷 (선택)  


---

🗣️ 공유사항 to 리뷰어  
리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 작성해주세요.  
논의해야할 부분이 있다면 적어주세요.  
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

---

✅ PR Checklist  
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention 참고](#)
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)  